### PR TITLE
Add annotation level

### DIFF
--- a/lib/output-generator.js
+++ b/lib/output-generator.js
@@ -88,7 +88,7 @@ class OutputGenerator {
           path: filename,
           start_line: result.line,
           end_line: result.line,
-          annotation_level: 'warning',
+          annotation_level: result.annotation_level || 'warning',
           message: result.reason
         })
       })

--- a/lib/providers/alex.js
+++ b/lib/providers/alex.js
@@ -14,7 +14,7 @@ class Alex {
    * @param {object[]} reasons
    */
   serializeReasons (reasons) {
-    return reasons.map(reason => ({ line: reason.line, reason: reason.message }))
+    return reasons.map(reason => ({ line: reason.line, reason: reason.message, annotation_level: reason.fatal ? 'failing' : 'warning' }))
   }
 
   /**

--- a/test/lib/providers/__snapshots__/alex.test.js.snap
+++ b/test/lib/providers/__snapshots__/alex.test.js.snap
@@ -4,12 +4,14 @@ exports[`Alex provider #buildResults returns the expected result 1`] = `
 Map {
   "guys.md" => Array [
     Object {
+      "annotation_level": "warning",
       "line": 1,
       "reason": "\`guys\` may be insensitive, use \`people\`, \`persons\`, \`folks\` instead",
     },
   ],
   "he.md" => Array [
     Object {
+      "annotation_level": "warning",
       "line": 1,
       "reason": "\`He\` may be insensitive, use \`They\`, \`It\` instead",
     },


### PR DESCRIPTION
Adds a configurable annotation level, mostly for the Alex provider to present `failing` annotations for `fatal: true` things.